### PR TITLE
return plain text response on accept any header "*/*"

### DIFF
--- a/internal/pkg/responder/responder-factory.go
+++ b/internal/pkg/responder/responder-factory.go
@@ -21,6 +21,8 @@ func (fac factory) Create(mimeType string) Responder {
 		return textHTMLResponder{}
 	case "text/plain":
 		return textPlainResponder{}
+	case "*/*":
+		return textPlainResponder{}
 	default:
 		return nil
 	}


### PR DESCRIPTION
Many url libraries (eg curl, httpie) send the accept any header "*/*", if the user omits the accept header.